### PR TITLE
Fix path to font source in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <style>
             @font-face {
                 font-family: "FastFont";
-                src: url("Fast_Sans.ttf") format("opentype");
+                src: url("fast-fonts/Fast_Sans.ttf") format("opentype");
                 font-display: swap;
             }
 


### PR DESCRIPTION
Noticed the demo page doesn't work:
https://born2root.github.io/Fast-Font/

Looks like your updated repo-structure 2 months ago moved the font to a new path, and the demo page needs that new path in it.